### PR TITLE
use compiler wrappers for the llvm toolchain

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -195,7 +195,7 @@ def init
 		when "gcc"
 			parsedConfig.store("cross_cc", "#{parsedConfig["triple"]}-gcc")
 		when "llvm"
-			parsedConfig.store("cross_cc", "clang")
+			parsedConfig.store("cross_cc", "#{parsedConfig["triple"]}-clang")
 			parsedConfig.store("cross_cflags", "--target=#{parsedConfig["triple"]} --sysroot=#{parsedConfig["sysroot"]}")
 		else
 			errorHandler("Unknown toolchain.", false)


### PR DESCRIPTION
should improve reliability and reproducibility, and allow me to simplify the 0.11 codebase a bit once we branch it off :3